### PR TITLE
Synethetic Tabular Benchmarks

### DIFF
--- a/hposuite/benchmarks/__init__.py
+++ b/hposuite/benchmarks/__init__.py
@@ -16,6 +16,8 @@ modules = [
     ("hposuite.benchmarks.synthetic", "ACKLEY_BENCH", "BRANIN_BENCH"),
     ("hposuite.benchmarks.mfp_bench", "mfpbench_benchmarks"),
     ("hposuite.benchmarks.pymoo", "pymoo_benchmarks"),
+    ("hposuite.benchmarks.bbob_tabular", "bbob_tabular_benchmarks"),
+    ("hposuite.benchmarks.mfh_tabular", "mfh_tabular_benchmarks"),
     ("hposuite.benchmarks.bbob", "bbob_benchmarks"),
 ]
 

--- a/hposuite/benchmarks/bbob_tabular.py
+++ b/hposuite/benchmarks/bbob_tabular.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import warnings
+from functools import partial
+from itertools import product
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from hpoglue import BenchmarkDescription, Config, Measure, TabularBenchmark
+
+bbob_functions_dict = {
+    #Separable
+
+    "f1": "Sphere",
+    "f2": "Ellipsoid separable",
+    "f3": "Rastrigin separable",
+    "f4": "Skew Rastrigin-Bueche",
+    "f5": "Linear slope",
+
+    # Low or moderate conditioning
+    "f6": "Attractive sector",
+    "f7": "Step-ellipsoid",
+    "f8": "Rosenbrock original",
+    "f9": "Rosenbrock rotated",
+
+    # High conditioning and unimodal
+    "f10": "Ellipsoid",
+    "f11": "Discus",
+    "f12": "Bent cigar",
+    "f13": "Sharp ridge",
+    "f14": "Sum of different powers",
+
+    # Multi-modal with adequate global structure
+    "f15": "Rastrigin",
+    "f16": "Weierstrass",
+    "f17": "Schaffer F7, condition 10",
+    "f18": "Schaffer F7, condition 1000",
+    "f19": "Griewank-Rosenbrock F8F2",
+
+    # Multi-modal with weak global structure
+    "f20": "Schwefel x*sin(x)",
+    "f21": "Gallagher 101 peaks",
+    "f22": "Gallagher 21 peaks",
+    "f23": "Katsuura",
+    "f24": "Lunacek bi-Rastrigin"
+}
+
+
+bbob_dims = (2, 3, 5, 10, 20, 40)
+bbob_instances = (0, 1, 2)
+
+def _get_bbob_space(
+    function_name: str,
+    datadir: str | Path | None = None,
+) -> list[Config]:
+    """Returns a list of all possible configurations for the BBOB function's Tabular Benchmark."""
+    table = _get_bbob_table(function_name, datadir)
+    config_keys = [k for k in table.columns if "x" in k]
+    return [
+        Config(config_id=str(i), values=config)  # enforcing str for id
+        for i, config in enumerate(
+            table[config_keys]
+            .drop_duplicates()
+            .sort_values(by=config_keys)  # Sorting to ensure table config order is consistent
+            .to_dict(orient="records"),
+        )
+    ]
+
+
+def _get_bbob_table(
+    function_name: str,
+    datadir: str | Path | None = None,
+) -> pd.DataFrame:
+    return pd.read_parquet(datadir / f"{function_name}.parquet")
+
+
+def _get_bbob_tabular_benchmark(
+    description: BenchmarkDescription,
+    *,
+    function_name: str,
+    datadir: str | Path | None = None,
+) -> TabularBenchmark:
+    """Creates a TabularBenchmark object for the BBOB Tabular Benchmark Suite."""
+    bench = _get_bbob_table(function_name, datadir)
+    config_keys = [k for k in bench.columns if "x" in k]
+    return TabularBenchmark(
+        desc=description,
+        table=bench,
+        id_key="config_id",
+        config_keys=config_keys,
+    )
+
+
+def bbob_tabular_desc(datadir: str | Path | None = None) -> BenchmarkDescription:
+    """Generates benchmark descriptions for the Synthetic BBOB Tabular Benchmark suite.
+
+    This function iterates over all combinations of function IDs, dimensions, and instances
+    defined in `bbob_functions_dict`, `bbob_dims`, and `bbob_instances` respectively. For each
+    combination, it creates a `BenchmarkDescription` object with the corresponding configuration
+    space, benchmark function, and environment settings.
+    """
+    for f_id, dim, ins in product(bbob_functions_dict.keys(), bbob_dims, bbob_instances):
+        function_name = f"{f_id}-{dim}-{ins}"
+        try:
+            space = _get_bbob_space(function_name, datadir)
+        except FileNotFoundError:
+            warnings.warn(  # noqa: B028
+                f"Could not find BBOB Tabular Benchmark data for {function_name}. Skipping."
+            )
+            continue
+        yield BenchmarkDescription(
+            name=f"bbob_tabular-{function_name}",
+            config_space=space,
+            load=partial(
+                _get_bbob_tabular_benchmark,
+                function_name=function_name,
+                datadir=datadir
+            ),
+            metrics={
+                "value": Measure.metric((-np.inf, np.inf), minimize=True),
+            },
+            test_metrics=None,
+            costs=None,
+            fidelities=None,
+            has_conditionals=False,
+            is_tabular=True,
+            mem_req_mb=1024,
+        )
+
+
+def bbob_tabular_benchmarks(datadir: str | Path | None = None) :
+    """A generator that yields all BBOB Tabular benchmarks."""
+    if isinstance(datadir, str):
+        datadir = Path(datadir).resolve()
+
+    if datadir is None:
+        datadir = Path("data", "bbob-tabular").resolve()
+
+    yield from bbob_tabular_desc(datadir=datadir)

--- a/hposuite/benchmarks/create_tabular.py
+++ b/hposuite/benchmarks/create_tabular.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import logging
+from argparse import ArgumentParser
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from hpoglue import BenchmarkDescription, Config, Query
+from hpoglue.fidelity import ContinuousFidelity, ListFidelity, RangeFidelity
+from scipy.stats import qmc
+
+from hposuite.benchmarks import BENCHMARKS
+from hposuite.constants import DATA_DIR
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+def _create_sobol_grid(n_samples, dim, seed=0) -> np.ndarray:
+    sobol = qmc.Sobol(d=dim, seed=seed)
+    return sobol.random(n_samples)
+
+
+def _scale_to_bounds(data: np.ndarray, bounds: np.ndarray) -> np.ndarray:
+    return qmc.scale(data, l_bounds=bounds[0], u_bounds=bounds[1])
+
+def _save_tabular(
+    df: pd.DataFrame,
+    save_dir: Path,
+    name: str,
+) -> None:
+    """Saves the tabular data to a parquet file."""
+    save_dir = save_dir / f"{name}.parquet"
+    df.to_parquet(save_dir)
+    logger.info(f"Saved tabular data to {save_dir.resolve()}.")
+
+
+def create_tabular(
+    n_samples: int,
+    benchmark_desc: BenchmarkDescription,
+    tabular_suite_name: str,
+    task: str,
+    seed: int = 0,
+    data_dir: Path = DATA_DIR,
+    fidelity: str | None = None,
+) -> None:
+    """Creates a Tabular Benchmark from the given Synthetic/Functional Benchmark."""
+    space = benchmark_desc.config_space
+    bench = benchmark_desc.load(benchmark_desc)
+    dim = len(space.values())
+
+    fidelity_space: tuple[str, list[int | float]] | None = None
+
+    if fidelity:
+        assert fidelity in benchmark_desc.fidelities, (
+            f"Fidelity {fidelity} not found in benchmark fidelities."
+        )
+        match benchmark_desc.fidelities[fidelity]:
+            case ContinuousFidelity():
+                sampled_fids = _create_sobol_grid(n_samples, 1, seed)
+                fidelity_space = (
+                    fidelity,
+                    _scale_to_bounds(
+                        sampled_fids,
+                        np.array([
+                            [
+                                benchmark_desc.fidelities[fidelity].min,
+                                benchmark_desc.fidelities[fidelity].max
+                            ]
+                        ])
+                    )
+                )
+            case ListFidelity():
+                fidelity_space = (fidelity, benchmark_desc.fidelities[fidelity].values)
+            case RangeFidelity():
+                _min, _max, _step = (
+                    benchmark_desc.fidelities[fidelity].min,
+                    benchmark_desc.fidelities[fidelity].max,
+                    benchmark_desc.fidelities[fidelity].stepsize
+                )
+                fidelity_space = (
+                    fidelity,
+                    np.arange(_min, _max + _step, _step)
+                )
+            case _:
+                raise TypeError(
+                    f"Unsupported fidelity type: {type(benchmark_desc.fidelities[fidelity])}"
+                )
+
+    logger.info(f"Generating {n_samples} configs using Sobol sequence for {benchmark_desc.name}.")
+    sampled_configs = _create_sobol_grid(n_samples, dim, seed)
+    config_dict = {}
+    bounds = np.array(
+        [
+            np.array([hp.lower, hp.upper])
+            for hp in space.values()
+        ]
+    ).T
+    assert bounds.shape == (2, dim), "Bounds shape mismatch."
+    assert bounds.shape[0] == 2, "First dimension of bounds must be 2." # noqa: PLR2004
+    assert bounds.shape[1] == dim, "Dimension mismatch."
+    scaled_configs = _scale_to_bounds(sampled_configs, bounds)
+
+    logger.info(f"Querying given benchmark for {n_samples} configs.")
+    for config_id, config in enumerate(scaled_configs, start=1):
+        configs= {
+            hp.name: config[i]
+            for i, hp in enumerate(space.values())
+        }
+        if fidelity:
+            for fid in fidelity_space[1]:
+                query = Query(
+                    config=Config(config_id=config_id, values=configs),
+                    fidelity=(fidelity, fid)
+                )
+                results = bench.query(query).values
+                config_dict[(config_id, fid)] = {
+                    **configs,
+                    **results
+                }
+            continue
+
+        query = Query(
+            config=Config(config_id=config_id, values=configs),
+            fidelity=None
+        )
+        results = bench.query(query).values
+        config_dict[config_id] = {
+            **configs,
+            **results
+        }
+
+    logger.info(f"Saving tabular data for {benchmark_desc.name}.")
+    _df = pd.DataFrame.from_dict(config_dict, orient="index")
+    if fidelity:
+        _df.index.names = ["config_id", fidelity]
+    else:
+        _df.index.name = "config_id"
+    print(_df.head())  # noqa: T201
+    save_dir = data_dir / tabular_suite_name
+    save_dir.mkdir(parents=True, exist_ok=True)
+    _save_tabular(_df, save_dir, f"{task}")
+
+
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser()
+    parser.add_argument(
+        "--n_samples", "-n",
+        type=int,
+        default=2000,
+        help="Number of configs to generate."
+    )
+    parser.add_argument(
+        "--benchmark", "-b",
+        type=str,
+        required=True,
+        help="Benchmark to create tabular benchmark for."
+    )
+    parser.add_argument(
+        "--seed", "-s",
+        type=int,
+        default=0,
+        help="Seed for reproducibility."
+    )
+    parser.add_argument(
+        "--data_dir", "-d",
+        type=str,
+        default=DATA_DIR,
+        help="Directory to save the tabular data."
+    )
+    parser.add_argument(
+        "--tabular_suite_name", "-suite",
+        type=str,
+        required=True,
+        help="Name of the tabular benchmark suite. Eg: bbob-tabular"
+    )
+    parser.add_argument(
+        "--task", "-t",
+        type=str,
+        required=True,
+        help="Name of the tabular benchmark. Eg: bbob function name: f1-2-0"
+    )
+    parser.add_argument(
+        "--fidelity", "-f",
+        type=str,
+        default=None,
+        help="Fidelity key to include in the tabular benchmark."
+    )
+    args = parser.parse_args()
+
+    benchmark = BENCHMARKS[args.benchmark]
+
+    if not isinstance(benchmark, BenchmarkDescription):
+        benchmark = benchmark.desc
+
+    if not isinstance(args.data_dir, Path):
+        args.data_dir = Path(args.data_dir)
+
+    create_tabular(
+        n_samples=args.n_samples,
+        benchmark_desc=benchmark,
+        tabular_suite_name=args.tabular_suite_name,
+        task=args.task,
+        data_dir=args.data_dir,
+        seed=args.seed,
+        fidelity=args.fidelity
+    )
+

--- a/hposuite/benchmarks/mfh_tabular.py
+++ b/hposuite/benchmarks/mfh_tabular.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import warnings
+from functools import partial
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from hpoglue import BenchmarkDescription, Config, Measure, TabularBenchmark
+from hpoglue.env import Env
+from hpoglue.fidelity import RangeFidelity
+
+
+def _get_mfh_space(
+    function_name: str,
+    datadir: str | Path | None = None,
+) -> list[Config]:
+    """Returns a list of all possible configurations for the MF Hartmann's Tabular Benchmark."""
+    table = _get_mfh_table(function_name, datadir)
+    config_keys = [k for k in table.columns if "X" in k]
+    return [
+        Config(config_id=str(i), values=config)  # enforcing str for id
+        for i, config in enumerate(
+            table[config_keys]
+            .drop_duplicates()
+            .sort_values(by=config_keys)  # Sorting to ensure table config order is consistent
+            .to_dict(orient="records"),
+        )
+    ]
+
+
+def _get_mfh_table(
+    function_name: str,
+    datadir: str | Path | None = None,
+) -> pd.DataFrame:
+    return pd.read_parquet(datadir / f"{function_name}.parquet")
+
+
+def _get_mfh_tabular_benchmark(
+    description: BenchmarkDescription,
+    *,
+    function_name: str,
+    datadir: str | Path | None = None,
+) -> TabularBenchmark:
+    """Creates a TabularBenchmark object for the MF-Hartmann Tabular Benchmark Suite."""
+    bench = _get_mfh_table(function_name, datadir)
+    config_keys = [k for k in bench.columns if "x" in k]
+    return TabularBenchmark(
+        desc=description,
+        table=bench,
+        id_key="config_id",
+        config_keys=config_keys,
+    )
+
+
+def mfh_tabular_desc(datadir: str | Path | None = None) -> BenchmarkDescription:
+    """Generates benchmark descriptions for the Synthetic MF-Hartmann Tabular Benchmark suite.
+
+    This function iterates over all combinations of function IDs, dimensions, and instances
+    defined in `mfh_functions_dict`, `mfh_dims`, and `mfh_instances` respectively. For each
+    combination, it creates a `BenchmarkDescription` object with the corresponding configuration
+    space, benchmark function, and environment settings.
+    """
+    for correlation in ("bad", "good", "moderate", "terrible"):
+        for dims in (3, 6):
+            name = f"mfh{dims}_{correlation}"
+            _min = -3.32237 if dims == 3 else -3.86278  # noqa: PLR2004
+            try:
+                space = _get_mfh_space(name, datadir)
+            except FileNotFoundError:
+                warnings.warn(  # noqa: B028
+                    f"Could not find mfh Tabular Benchmark data for {name}. Skipping."
+                )
+                continue
+            yield BenchmarkDescription(
+                name=f"mfh_tabular-{name}",
+                config_space=space,
+                load=partial(
+                    _get_mfh_tabular_benchmark,
+                    function_name=name,
+                    datadir=datadir
+                ),
+                costs={
+                    "fid_cost": Measure.cost((0.05, 1), minimize=True),
+                },
+                fidelities={
+                    "z": RangeFidelity.from_tuple((1, 100, 1), supports_continuation=True),
+                },
+                metrics={
+                    "value": Measure.metric((_min, np.inf), minimize=True),
+                },
+                has_conditionals=False,
+                is_tabular=False,
+                env=Env.empty(),
+                mem_req_mb = 1024,
+            )
+
+
+def mfh_tabular_benchmarks(datadir: str | Path | None = None) :
+    """A generator that yields all mfh Tabular benchmarks."""
+    if isinstance(datadir, str):
+        datadir = Path(datadir).resolve()
+
+    if datadir is None:
+        datadir = Path("data", "mfh-tabular").resolve()
+
+    yield from mfh_tabular_desc(datadir=datadir)

--- a/hposuite/constants.py
+++ b/hposuite/constants.py
@@ -3,3 +3,5 @@ from __future__ import annotations
 from pathlib import Path
 
 DEFAULT_STUDY_DIR = Path.cwd().absolute().parent / "hposuite-output"
+ROOT_DIR = Path(__file__).parent.parent.resolve()
+DATA_DIR = ROOT_DIR / "data"

--- a/hposuite/optimizers/random_search.py
+++ b/hposuite/optimizers/random_search.py
@@ -24,7 +24,7 @@ class RandomSearch(Optimizer):
         fidelities=(None,),
         objectives=("single", "many"),
         cost_awareness=(None, "single", "many"),
-        tabular=False,
+        tabular=True,
     )
 
     mem_req_mb = 100
@@ -59,10 +59,10 @@ class RandomSearch(Optimizer):
             case ConfigurationSpace():
                 config = Config(
                     config_id=str(self._counter),
-                    values=self.config_space.sample_configuration().get_dictionary(),
+                    values=dict(self.config_space.sample_configuration()),
                 )
             case list():
-                index = int(self.rng.integers(len(self.config_space)))
+                index = self.rng.integers(len(self.config_space))
                 config = self.config_space[index]
             case _:
                 raise TypeError("Config space must be a ConfigSpace or a list of Configs")
@@ -73,7 +73,9 @@ class RandomSearch(Optimizer):
             case (name, fidelity):
                 fidelity = (name, fidelity.max)
             case Mapping():
-                fidelity = {name: fidelity.max for name, fidelity in self.problem.fidelities.items()}
+                fidelity = {
+                    name: fidelity.max for name, fidelity in self.problem.fidelities.items()
+                }
             case _:
                 raise ValueError("Fidelity must be a string or a list of strings")
 


### PR DESCRIPTION
## Additions

* Code to generate Tabular benchmarks from synthetic benchmarks like bbob and mf-hartmann (only 1 fidelity queried at a time)
* BBOB and MF-Hartmann Tabular Benchmark Interfaces for hposuite
* Modified RandomSearch to handle Tabular Benchmarks